### PR TITLE
Engine files checksums

### DIFF
--- a/.circleci/sign-files.sh
+++ b/.circleci/sign-files.sh
@@ -53,7 +53,6 @@ function create_shasums_file() {
   cd "../${RELEASE}"
   ls -lahrt
   pwd
-  ls -lahrt
 }
 
 # Function to sign the SHA256SUMS file

--- a/.circleci/sign-files.sh
+++ b/.circleci/sign-files.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -x
 # This script is used to sign the release files with the GPG key
 set -euo pipefail
 
@@ -41,19 +40,12 @@ function process_files() {
 # Function to create the SHA256SUMS file
 function create_shasums_file() {
   pwd=$(pwd)
-  ls -lahrt
-  pwd
   cd "${BIN}"
-  pwd
-  ls -lahrt
   # Create the SHA256SUMS file for all files in the release directory
   shasum -a 256 * > "terragrunt-iac-engine-${NAME}_${TYPE}_${VERSION}_SHA256SUMS"
   cp *.zip ../"${RELEASE}"
   cp "terragrunt-iac-engine-${NAME}_${TYPE}_${VERSION}_SHA256SUMS" ../"${RELEASE}"
-  ls -lahrt
   cd "../${RELEASE}"
-  ls -lahrt
-  pwd
 }
 
 # Function to sign the SHA256SUMS file

--- a/.circleci/sign-files.sh
+++ b/.circleci/sign-files.sh
@@ -40,12 +40,19 @@ function process_files() {
 
 # Function to create the SHA256SUMS file
 function create_shasums_file() {
+  pwd=$(pwd)
+  ls -lahrt
   cd "${BIN}"
+  ls -lahrt
   # Create the SHA256SUMS file for all files in the release directory
   shasum -a 256 * > "terragrunt-iac-engine-${NAME}_${TYPE}_${VERSION}_SHA256SUMS"
+  ls -lahrt
   cd "../${RELEASE}"
+  ls -lahrt
+  pwd
   # collect release files
-  cp -Rfv "../${BIN}/*" .
+  cp -Rfv "${pwd}/${BIN}/*" .
+  ls -lahrt
 }
 
 # Function to sign the SHA256SUMS file

--- a/.circleci/sign-files.sh
+++ b/.circleci/sign-files.sh
@@ -42,7 +42,9 @@ function process_files() {
 function create_shasums_file() {
   pwd=$(pwd)
   ls -lahrt
+  pwd
   cd "${BIN}"
+  pwd
   ls -lahrt
   # Create the SHA256SUMS file for all files in the release directory
   shasum -a 256 * > "terragrunt-iac-engine-${NAME}_${TYPE}_${VERSION}_SHA256SUMS"
@@ -51,7 +53,7 @@ function create_shasums_file() {
   ls -lahrt
   pwd
   # collect release files
-  cp -Rfv "${pwd}/${BIN}/*" .
+  cp -fv "${pwd}/${BIN}/*" .
   ls -lahrt
 }
 

--- a/.circleci/sign-files.sh
+++ b/.circleci/sign-files.sh
@@ -45,9 +45,7 @@ function create_shasums_file() {
   shasum -a 256 * > "terragrunt-iac-engine-${NAME}_${TYPE}_${VERSION}_SHA256SUMS"
   cd "../${RELEASE}"
   # collect release files
-  cp "../${BIN}/terragrunt-iac-engine-${NAME}_${TYPE}_${VERSION}_SHA256SUMS" .
-  cp "../${BIN}/*.zip" .
-
+  cp -Rfv "../${BIN}/*" .
 }
 
 # Function to sign the SHA256SUMS file

--- a/.circleci/sign-files.sh
+++ b/.circleci/sign-files.sh
@@ -48,12 +48,11 @@ function create_shasums_file() {
   ls -lahrt
   # Create the SHA256SUMS file for all files in the release directory
   shasum -a 256 * > "terragrunt-iac-engine-${NAME}_${TYPE}_${VERSION}_SHA256SUMS"
+  cp * ../"${RELEASE}"
   ls -lahrt
   cd "../${RELEASE}"
   ls -lahrt
   pwd
-  # collect release files
-  cp -fv "${pwd}/${BIN}/*" .
   ls -lahrt
 }
 

--- a/.circleci/sign-files.sh
+++ b/.circleci/sign-files.sh
@@ -48,7 +48,8 @@ function create_shasums_file() {
   ls -lahrt
   # Create the SHA256SUMS file for all files in the release directory
   shasum -a 256 * > "terragrunt-iac-engine-${NAME}_${TYPE}_${VERSION}_SHA256SUMS"
-  cp * ../"${RELEASE}"
+  cp *.zip ../"${RELEASE}"
+  cp "terragrunt-iac-engine-${NAME}_${TYPE}_${VERSION}_SHA256SUMS" ../"${RELEASE}"
   ls -lahrt
   cd "../${RELEASE}"
   ls -lahrt

--- a/.circleci/sign-files.sh
+++ b/.circleci/sign-files.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 # This script is used to sign the release files with the GPG key
 set -euo pipefail
 
@@ -26,7 +27,7 @@ function process_files() {
       ARCH="${BASH_REMATCH[2]}"
 
       # Set the binary and archive names
-      BINARY_NAME="terragrunt-iac-engine-${NAME}_${VERSION}"
+      BINARY_NAME="terragrunt-iac-engine-${NAME}_${TYPE}_${VERSION}_${OS}_${ARCH}"
       mv "${file}" "${BINARY_NAME}"
       ARCHIVE_NAME="terragrunt-iac-engine-${NAME}_${TYPE}_${VERSION}_${OS}_${ARCH}.zip"
 

--- a/.circleci/sign-files.sh
+++ b/.circleci/sign-files.sh
@@ -42,7 +42,7 @@ function create_shasums_file() {
   cd "${BIN}"
   # Create the SHA256SUMS file for all files in the release directory
   shasum -a 256 * > "terragrunt-iac-engine-${NAME}_${TYPE}_${VERSION}_SHA256SUMS"
-  cd "${RELEASE}"
+  cd "../${RELEASE}"
   # collect release files
   cp "../${BIN}/terragrunt-iac-engine-${NAME}_${TYPE}_${VERSION}_SHA256SUMS" .
   cp "../${BIN}/*.zip" .


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Added inclusion of checksums for engine files in SHA256SUMS file

After changes from this PR, checksum file looks like this:
```
1907e031d959c3bec469f36cf2a27428d231fa11a1efda3d63c8e6923ff88dfc  terragrunt-iac-engine-opentofu_rpc_v0.0.4_darwin_amd64
e9a1835fd09948e67f44f315bcf89c629dea5dcdf748fc6b07311091db83f52d  terragrunt-iac-engine-opentofu_rpc_v0.0.4_darwin_amd64.zip
e0252167c9793204bc906667969295d622131899d30288894cfe671ea03bb323  terragrunt-iac-engine-opentofu_rpc_v0.0.4_darwin_arm64
578e6059f74f67b7676a538b34199f3d302ed75143cdf6508a4ae15354970259  terragrunt-iac-engine-opentofu_rpc_v0.0.4_darwin_arm64.zip
a049182c39e22b295d7bcf38dfc8a08b5709724b77108e11e3683d61ddceb9e8  terragrunt-iac-engine-opentofu_rpc_v0.0.4_linux_386
c2e69e0011dc36917586c630b8dbbb703d00f2fcd4108c064c0ac80922cf7acd  terragrunt-iac-engine-opentofu_rpc_v0.0.4_linux_386.zip
8b022ddb8014a91c53467acb98f807a69c6ebced4b491b6141b2ae81eea06cac  terragrunt-iac-engine-opentofu_rpc_v0.0.4_linux_amd64
a862ede3e49e4dbee00b90e7d2fc8e734a706f5b918669073628d31d99ce2473  terragrunt-iac-engine-opentofu_rpc_v0.0.4_linux_amd64.zip
f32cc85ac08d2effc3378dcb20c74d44712211121f3e2a7e361b35136b2eb97b  terragrunt-iac-engine-opentofu_rpc_v0.0.4_linux_arm64
1eb246c1f844438108311f8dab100b72bdf6c55afdd262935cebf7f6f642d6c7  terragrunt-iac-engine-opentofu_rpc_v0.0.4_linux_arm64.zip
19d6383ca11d0c2f9e310499a5247456612753790918efa8cf73bdf154d0eb8b  terragrunt-iac-engine-opentofu_rpc_v0.0.4_windows_386.exe
b70bee3c163256cc13844b485f73bf8baadb37f8f24ed196e3e52b6e92059874  terragrunt-iac-engine-opentofu_rpc_v0.0.4_windows_386.exe.zip
e3d490286df2ef5ff28b322fcbe457e61cdead61c54de71dc5e203fee1f68df8  terragrunt-iac-engine-opentofu_rpc_v0.0.4_windows_amd64.exe
b75a5aa2c6c15972f37aef25cf046d7ad7ff6883d42f99962863232df335e615  terragrunt-iac-engine-opentofu_rpc_v0.0.4_windows_amd64.exe.zip
```
And can be checked checksums for ZIPs and executables

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

