### PR TITLE
feat: Setup Terragrunt Lint Tracking

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,12 @@
+# This file is generated using `make update-local-lint` to track the linting used in Terragrunt. Do not edit manually.
 run:
   timeout: 2m
   issues-exit-code: 1
   tests: true
-  skip-dirs:
-    - docs
-    - _ci
-    - .github
-    - .circleci
+  go: "1.22"
 output:
-  format: colored-line-number
+  formats:
+    - format: colored-line-number
   print-issued-lines: true
   print-linter-name: true
 
@@ -28,21 +26,11 @@ linters-settings:
     comparison: true
   gofmt:
     simplify: true
-  gofumpt:
-    lang-version: "1.21"
-    extra-rules: false
-  gosimple:
-    go: "1.21"
-    checks: [ "all" ]
   dupl:
     threshold: 120
   goconst:
     min-len: 3
     min-occurrences: 5
-  gomnd:
-    settings:
-      mnd:
-        ignored-functions: strconv.Format*,os.*,strconv.Parse*,strings.SplitN,bytes.SplitN
   revive:
     min-confidence: 0.8
   unused:
@@ -69,24 +57,55 @@ linters:
     - goconst
     - gocritic
     - goimports
-    - gomnd
+    - mnd
     - gosimple
     - govet
     - ineffassign
-    - megacheck
+    - staticcheck
     - misspell
     - unconvert
     - unused
     - unparam
+    - wsl
+    - thelper
+    - wastedassign
+
   enable-all: false
   disable:
     - depguard
     - gosec
-    - interfacer
     - gocyclo
+    - exhaustruct
+
   fast: false
+  mnd:
+    ignored-functions: strconv.Format*,os.*,strconv.Parse*,strings.SplitN,bytes.SplitN
+  presets:
+    - bugs
+    - performance
+    - unused
+    - test
+    # NOTE: These two are only in the strict lint right now
+    # - style
+    # - complexity
 
 issues:
+  exclude-dirs:
+    - docs
+    - _ci
+    - .github
+    - .circleci
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - dupl
+        - gocyclo
+        - lll
+        - errcheck
+        - wsl
+        - mnd
+        - unparam
+
   exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,21 @@ build: $(shell find . \( -type f -name '*.go' -print \))
 clean:
 	rm -f engine
 
+lint: SHELL:=/bin/bash
 lint:
-	golangci-lint run ./...
+	golangci-lint run -c <(curl -s https://raw.githubusercontent.com/gruntwork-io/terragrunt/master/.golangci.yml) ./...
+
+update-local-lint: SHELL:=/bin/bash
+update-local-lint:
+	curl -s https://raw.githubusercontent.com/gruntwork-io/terragrunt/master/.golangci.yml --output .golangci.yml
+	tmpfile=$$(mktemp) ;\
+	echo '# This file is generated using `make update-local-lint` to track the linting used in Terragrunt. Do not edit manually.' | cat - .golangci.yml > $${tmpfile} && mv $${tmpfile} .golangci.yml
 
 test:
 	go test -v ./...
 
 tools:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
 
 fmt:
 	@echo "Running source files through gofmt..."

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -153,8 +153,7 @@ func (c *TofuEngine) Run(req *tgengine.RunRequest, stream tgengine.Engine_RunSer
 
 	resultCode := 0
 
-	err = cmd.Wait()
-	if err != nil {
+	if err := cmd.Wait(); err != nil {
 		var exitError *exec.ExitError
 		if ok := errors.As(err, &exitError); ok {
 			resultCode = exitError.ExitCode()

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1,17 +1,17 @@
-package engine
+package engine_test
 
 import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"os"
 	"os/exec"
 
 	tgengine "github.com/gruntwork-io/terragrunt-engine-go/proto"
+	"github.com/gruntwork-io/terragrunt-engine-opentofu/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -119,19 +119,19 @@ func (m *MockShutdownServer) RecvMsg(msg interface{}) error {
 
 func TestTofuEngine_Init(t *testing.T) {
 	t.Parallel()
-	engine := &TofuEngine{}
+	engine := &engine.TofuEngine{}
 	mockStream := &MockInitServer{}
 
 	err := engine.Init(&tgengine.InitRequest{}, mockStream)
 	require.NoError(t, err)
-	assert.Equal(t, 2, len(mockStream.Responses))
-	assert.Equal(t, "Tofu Initialization started\n", mockStream.Responses[0].Stdout)
-	assert.Equal(t, "Tofu Initialization completed\n", mockStream.Responses[1].Stdout)
+	assert.Len(t, mockStream.Responses, 2)
+	assert.Equal(t, "Tofu Initialization started\n", mockStream.Responses[0].GetStdout())
+	assert.Equal(t, "Tofu Initialization completed\n", mockStream.Responses[1].GetStdout())
 }
 
 func TestTofuEngine_Run(t *testing.T) {
 	t.Parallel()
-	engine := &TofuEngine{}
+	engine := &engine.TofuEngine{}
 	mockStream := &MockRunServer{}
 
 	cmd := "tofu"
@@ -143,20 +143,21 @@ func TestTofuEngine_Run(t *testing.T) {
 	}
 	err := engine.Run(req, mockStream)
 	require.NoError(t, err)
-	assert.True(t, len(mockStream.Responses) > 0)
+	assert.NotEmpty(t, mockStream.Responses)
 	// merge stdout from all responses to a string
 	var output string
 	for _, response := range mockStream.Responses {
-		if response.Stdout != "" {
-			output += response.Stdout
+		if response.GetStdout() != "" {
+			output += response.GetStdout()
 		}
 	}
+
 	assert.Contains(t, output, "Usage: tofu [global options] <subcommand> [args]")
 }
 
 func TestTofuEngineError(t *testing.T) {
 	t.Parallel()
-	engine := &TofuEngine{}
+	engine := &engine.TofuEngine{}
 	mockStream := &MockRunServer{}
 
 	cmd := "tofu"
@@ -167,30 +168,30 @@ func TestTofuEngineError(t *testing.T) {
 	}
 	err := engine.Run(req, mockStream)
 	require.NoError(t, err)
-	assert.True(t, len(mockStream.Responses) > 0)
+	assert.NotEmpty(t, mockStream.Responses)
 	// merge stdout from all responses to a string
 	var output string
 
 	for _, response := range mockStream.Responses {
-		if response.Stderr != "" {
-			output += response.Stderr
+		if response.GetStderr() != "" {
+			output += response.GetStderr()
 		}
 	}
 	// get status code from last response
-	code := mockStream.Responses[len(mockStream.Responses)-1].ResultCode
+	code := mockStream.Responses[len(mockStream.Responses)-1].GetResultCode()
 	assert.Contains(t, output, "OpenTofu has no command named \"not-a-valid-command\"")
 	assert.NotEqual(t, 0, code)
 }
 
 func TestTofuEngine_Shutdown(t *testing.T) {
 	t.Parallel()
-	engine := &TofuEngine{}
+	engine := &engine.TofuEngine{}
 	mockStream := &MockShutdownServer{}
 
 	err := engine.Shutdown(&tgengine.ShutdownRequest{}, mockStream)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(mockStream.Responses))
-	assert.Equal(t, "Tofu Shutdown completed\n", mockStream.Responses[0].Stdout)
+	assert.Len(t, mockStream.Responses, 1)
+	assert.Equal(t, "Tofu Shutdown completed\n", mockStream.Responses[0].GetStdout())
 }
 
 func TestHelperProcess(*testing.T) {

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -1,4 +1,4 @@
-package test
+package integration_test
 
 import (
 	"context"
@@ -65,6 +65,10 @@ func bufDialer(context.Context, string) (net.Conn, error) {
 }
 
 func runTofuCommand(t *testing.T, ctx context.Context, command string, args []string, workingDir string, envVars map[string]string) (string, string, error) {
+	t.Helper()
+
+	// TODO: Update the deprecated usage of DialContext and WithInsecure below
+
 	// nolint:staticcheck
 	conn, err := grpc.DialContext(ctx, "", grpc.WithContextDialer(bufDialer), grpc.WithInsecure())
 	if err != nil {
@@ -95,15 +99,15 @@ func runTofuCommand(t *testing.T, ctx context.Context, command string, args []st
 			break
 		}
 
-		stdout.WriteString(resp.Stdout)
-		stderr.WriteString(resp.Stderr)
+		stdout.WriteString(resp.GetStdout())
+		stderr.WriteString(resp.GetStderr())
 
-		_, err = fmt.Fprint(os.Stdout, resp.Stdout)
+		_, err = fmt.Fprint(os.Stdout, resp.GetStdout())
 		if err != nil {
 			return "", "", err
 		}
 
-		_, err = fmt.Fprint(os.Stderr, resp.Stderr)
+		_, err = fmt.Fprint(os.Stderr, resp.GetStderr())
 		if err != nil {
 			return "", "", err
 		}


### PR DESCRIPTION
## Description

This makes it so that the project tracks Terragrunt's lint configurations.

It will fetch them dynamically when running `make lint`, and has a script to update it locally via `make update-terragrunt-lint` keeping the file updated locally can be useful, as it allows for editors to leverage it, and to test out new lints.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated linting configurations to include Terragrunt's lint configurations.

